### PR TITLE
Ft/#2 update readme

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -3,7 +3,7 @@ version: 2.1
 description: >
   Build, preview and publish Leanpub books.
   
-  You must obtain a Leanpub API key before running this orb.
+  You must obtain a Leanpub API key before running this orb - https://leanpub.com/help/api
 
   View this orb's source - https://github.com/zzamboni/leanpub-orb
   View this orb's guide - https://circleci.com/orbs/registry/orb/zzamboni/leanpub

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,7 +5,7 @@ description: >
   
   You must obtain a Leanpub API key before running this orb.
 
-  View this orb's source - https://github.com/CircleCI-Public/slack-orb
+  View this orb's source - https://github.com/zzamboni/leanpub-orb
   View this orb's guide - https://circleci.com/orbs/registry/orb/zzamboni/leanpub
 
 orbs:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,6 +1,8 @@
 version: 2.1
 
-description: Build, preview and publish Leanpub books
+description: >
+  Build, preview and publish Leanpub books.
+  View this orb's source - https://github.com/CircleCI-Public/slack-orb
 
 orbs:
   orb-tools: circleci/orb-tools@8.6.0

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,7 +2,11 @@ version: 2.1
 
 description: >
   Build, preview and publish Leanpub books.
+  
+  You must obtain a Leanpub API key before running this orb.
+
   View this orb's source - https://github.com/CircleCI-Public/slack-orb
+  View this orb's guide - https://circleci.com/orbs/registry/orb/zzamboni/leanpub
 
 orbs:
   orb-tools: circleci/orb-tools@8.6.0


### PR DESCRIPTION
Resolves #2 

Adding description metadata for:
* Github repo link
* Registry guide link
* Pre-requisite of getting Leanpub API key prior to running orb.